### PR TITLE
update gems for security fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rspec', '2.13.0'
 gem 'rspec-core', '2.13.1'
 gem 'rspec-expectations', '2.13.0'
 gem 'rspec-mocks', '2.13.1'
-gem 'puppet', '3.2.1'
+gem 'puppet', '3.2.2'
 gem 'rspec-puppet', '0.1.6'
 gem 'puppetlabs_spec_helper', '0.4.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rspec', '2.13.0'
 gem 'rspec-core', '2.13.1'
 gem 'rspec-expectations', '2.13.0'
 gem 'rspec-mocks', '2.13.1'
-gem 'puppet', '3.2.2'
+gem 'puppet', '>= 3.2.2',  '< 4'
 gem 'rspec-puppet', '0.1.6'
 gem 'puppetlabs_spec_helper', '0.4.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    facter (1.7.6)
+    facter (2.5.1)
     hiera (1.3.4)
       json_pure
     hoe (3.17.0)
@@ -11,10 +11,10 @@ GEM
     metaclass (0.0.1)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
-    puppet (3.2.2)
-      facter (~> 1.6)
+    puppet (3.8.7)
+      facter (> 1.6, < 3)
       hiera (~> 1.0)
-      rgen (~> 0.6)
+      json_pure
     puppet-lint (0.3.2)
     puppetlabs_spec_helper (0.4.1)
       mocha (>= 0.10.5)
@@ -22,7 +22,6 @@ GEM
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.0.4)
-    rgen (0.8.2)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -41,7 +40,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  puppet (= 3.2.2)
+  puppet (>= 3.2.2, < 4)
   puppet-lint
   puppetlabs_spec_helper (= 0.4.1)
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,16 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    facter (1.7.1)
-    hiera (1.2.1)
+    facter (1.7.6)
+    hiera (1.3.4)
       json_pure
-    json_pure (1.8.0)
+    hoe (3.17.0)
+      rake (>= 0.8, < 13.0)
+    json_pure (2.1.0)
     metaclass (0.0.1)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
-    puppet (3.2.1)
+    puppet (3.2.2)
       facter (~> 1.6)
       hiera (~> 1.0)
       rgen (~> 0.6)
@@ -20,7 +22,7 @@ GEM
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.0.4)
-    rgen (0.6.2)
+    rgen (0.8.2)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -31,13 +33,15 @@ GEM
     rspec-mocks (2.13.1)
     rspec-puppet (0.1.6)
       rspec
+    test-unit (2.0.0)
+      hoe (>= 1.6.0)
     test-unit (2.0.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  puppet (= 3.2.1)
+  puppet (= 3.2.2)
   puppet-lint
   puppetlabs_spec_helper (= 0.4.1)
   rake
@@ -47,3 +51,6 @@ DEPENDENCIES
   rspec-mocks (= 2.13.1)
   rspec-puppet (= 0.1.6)
   test-unit
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
puppet >= 3.2.2

CVE-2013-3567 High severity
CVE-2014-3248 Moderate severity
CVE-2013-4761 Moderate severity

facter >= 1.7.6

CVE-2014-3248 Moderate severity

hiera >= 1.3.4

CVE-2014-3248 Moderate severity

notified from github.
https://github.com/opentable/puppet-teamcity/network/dependencies

these are only used to run specs i believe. and specs pass.